### PR TITLE
V0.1.8

### DIFF
--- a/cipher.css
+++ b/cipher.css
@@ -1,22 +1,18 @@
 :root {
   --slate: #7D869C;
-  --deepblue: #646B7D;
   --khaki: #C7AC92;
   --dust: #F9E9D9;
-  --xgray: #C0BABC;
-  --platinum: #E0D1C3;
   --purple: #453750;
   --deeppurple: #372C40;
   --lightpurple: #50475F;
-  --ucla: #586994;
 }
 
 body {
   background: var(--purple);
   margin: 3vh auto;
-  min-width: 270px;
+  min-width: 310px;
   max-width: 1160px;
-  height: 100vh;
+  height: 90vh;
   font-family: Thasadith, arial;
   letter-spacing: 0.11em;
   text-align: center;
@@ -25,7 +21,7 @@ body {
 
 header {
   position: relative;
-  margin: 3vh;
+  margin: 3vh 3.8vh;
   padding: 3px;
 }
 
@@ -91,10 +87,15 @@ h2 {
 }
 
 textarea {
-  min-height: 60vh;
+  min-height: 58.8vh;
   width: 97%;
   font-size: 16px;
   letter-spacing: 0.09em;
+}
+
+#button-container {
+  display: flex;
+  justify-content: space-between;
 }
 
 .button {
@@ -129,6 +130,10 @@ textarea {
   cursor: pointer;
 }
 
+#mobile-copy-button {
+  display: none;
+}
+
 #value-display {
   display: flex;
   justify-content: center;
@@ -138,7 +143,6 @@ textarea {
   left: 40%;
   width: 20.5%;
   height: 19.5%;
-/*   transform: rotate(-76.1deg); */
   border-radius: 50%;
   font-size: 20px;
   font-weight: bold;
@@ -193,4 +197,82 @@ hr {
   padding-top: 100%;
   border-radius: 50%;
   box-shadow: 0 0 14px 3px rgba(0,0,0,0.34);
+}
+
+
+/* MEDIA QUERIES */
+@media only screen and (max-width: 660px) {
+  #bg-shape::after {
+    width: 145%;
+  }
+  
+  #title-box {
+    margin-top: 40px;
+    width: auto;
+  }
+  
+  h2 {
+    display: none;
+  }
+  
+  #james-hooper-logo {
+    background-image: url(https://i.ibb.co/tsSSpHy/logo-small-deep-purple-dust.png);
+    background-size: contain;
+    background-repeat: no-repeat;
+    position: absolute;
+    top: 74px;
+    right: -170px;
+    z-index: -1;
+  }
+  
+  #app-contents {
+    flex-direction: column;
+    margin: -22px auto 22px auto;
+  }
+  
+  .main-container {
+    width: auto;
+    margin: 0;
+  }
+  
+  textarea {
+    min-height: 24vh;
+  }
+  
+  #mobile-copy-button {
+    display: block;
+  }
+  
+  #output-box {
+    display: none;
+  }
+  
+  #offset-wheel {
+    float: left;
+    width: 45%;
+    padding-top: 45%;
+    margin: 6px;
+  }
+  
+  #settings-box {
+    margin-top: 12px;
+  }
+  
+  #incrementers {
+    flex-direction: column-reverse;
+  }
+  
+  #case-sensitive-toggles {
+    flex-direction: column;
+  }
+  
+  .option {
+    margin: 6px;
+  }
+}
+
+@media only screen and (max-width: 530px) {
+  #case-sensitive-toggles {
+    flex-direction: row;
+  }
 }

--- a/cipher.js
+++ b/cipher.js
@@ -1,4 +1,4 @@
-// DEFINE VARIABLES
+// VARIABLES
 const INPUT_TEXT = document.getElementById("input-text");
 const OFFSET_VALUE = document.getElementById("offset-value");
 const CASE_ON = document.getElementById("case-sensitive-on");
@@ -9,35 +9,34 @@ const VALUE_DISPLAY = document.getElementById("value-display");
 
 let offset = 1;
 let isCaseSensitive = true;
+let destination = "";
+let inputProxy = "";
 
 
 
-// DEFINE FUNCTIONS
-// Take inputText and offset and return ciphered text
+// FUNCTIONS
+const setProxy = () => inputProxy = INPUT_TEXT.value;
+
+const checkDestination = () => destination = areWeMobile() === false ? OUTPUT_TEXT : INPUT_TEXT;
+
 function cipher() {
-  let inputText = INPUT_TEXT.value || INPUT_TEXT.placeholder;
+  let inputText = inputProxy || INPUT_TEXT.placeholder;
   offset = parseInt(OFFSET_VALUE.innerHTML);
   return inputText.replace(/[A-Z]/gi, checkUpperOrLower);
 }
 
-// Determine how to handle each character
 const checkUpperOrLower = (letter) => letter.charCodeAt(0) < 94 ?
       String.fromCharCode((letter.charCodeAt(0) + 13 + offset) % 26 + 65) :
       String.fromCharCode((letter.charCodeAt(0) + 7 + offset) % 26 + checkCaseSensitivity());
 
-// Check the case of a letter and return correct number to calculate output from input (65 to caps, 97 to lowercase)
-function checkCaseSensitivity() {
-  const ASCII_VALUE = isCaseSensitive === true ? 97 : 65;
-  return ASCII_VALUE;
-}
+const checkCaseSensitivity = () => isCaseSensitive === true ? 97 : 65;
 
-// Mutate the DOM and render outputText
-const renderOutput = () => OUTPUT_TEXT.innerHTML = cipher();
+const renderOutput = () => destination.value = cipher();
 
-// Copy contents to clipboard
-const copyContent = () => window.prompt("Copy to clipboard: Ctrl+C, enter", OUTPUT_TEXT.innerHTML);
+const areWeMobile = () => window.innerWidth <= 660 ? true : false;
 
-// Increment the offset value
+const copyContent = () => window.prompt("Copy to clipboard: Ctrl+C, enter", destination.value);
+
 function increment() {
   offset++;
   OFFSET_VALUE.innerHTML = (offset + 26) % 26;
@@ -45,7 +44,6 @@ function increment() {
   rotateWheel(-13.85);
 }
 
-// Decerement the offset value
 function decrement() {
   offset--;
   OFFSET_VALUE.innerHTML = (offset + 26) % 26;
@@ -58,7 +56,6 @@ function rotateWheel(degrees) {
   VALUE_DISPLAY.style.transform += `rotate(${degrees * -1}deg)`
 }
 
-// Toggle case sensitive on/off
 function toggleCaps() {
   isCaseSensitive = this.id === "case-sensitive-on" ? true : false;
   if (isCaseSensitive === true) {
@@ -73,17 +70,21 @@ function toggleCaps() {
 
 
 
-// ADD EVENT LISTENERS
+// EVENT LISTENERS
+document.getElementById("input-text").addEventListener("input", setProxy);
 document.getElementById("encrypt-button").addEventListener("click", renderOutput);
-document.getElementById("copy-button").addEventListener("click", copyContent);
+document.getElementById("desktop-copy-button").addEventListener("click", copyContent);
+document.getElementById("mobile-copy-button").addEventListener("click", copyContent);
 document.getElementById("increment-offset").addEventListener("click", increment);
 document.getElementById("decrement-offset").addEventListener("click", decrement);
 CASE_ON.addEventListener("click", toggleCaps);
 CASE_OFF.addEventListener("click", toggleCaps);
+window.addEventListener("resize", checkDestination);
 
 
 
 // FUNCTIONS TO RUN ON PAGE LOAD
 window.onload = function() {
+  checkDestination();
   renderOutput();
 }


### PR DESCRIPTION
**CSS:**
Added mobile styling: output box leaves, the two remaining boxes stack vertically, wheel floats left of the settings buttons.
Removed unused colour variables.
Fixed the height and width so that the app fits onto the screen.
Re-aligned the header.
Put the buttons below the first box into a flex container and hid the copy button for use only on mobile.
Removed the rotate CSS as I altered the image to be the correct angle instead.

**JS:**
On the new mobile layout, I wanted to use just one box for input and output. To do so, I had to create a proxy input (like a memory) and change the cipher from automatically working on INPUT_TEXT after every settings change/encrypt click to working on the input proxy, which is only updated when the textarea receives input. This allowed me to take the input proxy value, run it through cipher, and then paste it into the input box directly.
I changed most of the functions to use ES6 arrow syntax. With most functions being a ternary or imperative command, this was light work but the result is clean, tidy code.
I added a couple of const functions to check whether the device was in mobile- or desktop-view and to set the output path accordingly.